### PR TITLE
Raise an error if the codon usage table is not found for the given taxonomy ID

### DIFF
--- a/python_codon_tables/python_codon_tables.py
+++ b/python_codon_tables/python_codon_tables.py
@@ -80,6 +80,8 @@ def download_codons_table(taxid=316407, target_file=None):
     _codon_regexpr = r"([ATGCU]{3}) ([A-Z]|\*) (\d.\d+)"
     url = _kazusa_url % taxid
     html_content = urlopen(url).read().decode().replace("\n", " ")
+    if "<title>not found</title>" in html_content.lower():
+        raise RuntimeError(f'Codon usage table for taxonomy ID \'{taxid}\' not found: {url}')
     csv_data = "\n".join(["amino_acid,codon,relative_frequency"] + sorted([
         "%s,%s,%s" % (aa, codon, usage)
         for codon, aa, usage in re.findall(_codon_regexpr, html_content)

--- a/python_codon_tables/python_codon_tables.py
+++ b/python_codon_tables/python_codon_tables.py
@@ -81,7 +81,9 @@ def download_codons_table(taxid=316407, target_file=None):
     url = _kazusa_url % taxid
     html_content = urlopen(url).read().decode().replace("\n", " ")
     if "<title>not found</title>" in html_content.lower():
-        raise RuntimeError(f'Codon usage table for taxonomy ID \'{taxid}\' not found: {url}')
+        raise RuntimeError("Codon usage table for taxonomy ID '%s' not found:"
+                           " %s"
+                           % (taxid, url))
     csv_data = "\n".join(["amino_acid,codon,relative_frequency"] + sorted([
         "%s,%s,%s" % (aa, codon, usage)
         for codon, aa, usage in re.findall(_codon_regexpr, html_content)


### PR DESCRIPTION
No idea if this is still maintained, but it would be nice to raise an error when the usage table isn't available on the website.

I mainly wanted this feature in https://github.com/Edinburgh-Genome-Foundry/DnaChisel, but didn't see the custom python_codon_tables code in that repo (I believe you add a `web_timeout` there that isn't in this repo?).